### PR TITLE
subCreateSynth: changed sampleOffset int type to int32_t

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/*
+.DS_Store

--- a/src/synth.h
+++ b/src/synth.h
@@ -37,7 +37,7 @@ struct kit_t
 };
 
 // times in milliseconds, frequencies in hZ
-void subCreateSynth(sample_t *sample, int32_t samplerate, synth_t *synth, int sampleOffset, float ampScale);
+void subCreateSynth(sample_t *sample, int32_t samplerate, synth_t *synth, int32_t sampleOffset, float ampScale);
 void createSynth(sample_t *sample, int32_t samplerate, synth_t *synth);
 inline float randFloat();
 


### PR DESCRIPTION
The function definitions were different between synth.h and synth.cc - preventing compile